### PR TITLE
docs: Adiciona seção de Contribuidores no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Mais uma vez, queremos agradecer a vocês por estarem dispostos a contribuir com
 
 - Só o tempo dirá... 👀
 
+## 😊 Contribuidores
+
+<a href="https://github.com/diego3g/rsxp-2023/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=diego3g/rsxp-2023" />
+</a>
+
 ## Licença 📃
 
 [MIT](https://github.com/diego3g/rsxp-2023/blob/main/LICENSE)


### PR DESCRIPTION
Por ser um projeto open source, pode incentivar mais o pessoal a participar se tiver o rostinho ali no README na seção de contribuidores.

Feito com [Contrib Rocks](https://contrib.rocks/preview?repo=diego3g%2Frsxp-2023)

## Preview 

![image](https://user-images.githubusercontent.com/25696006/228688059-075a9229-ccd9-41b0-afd7-25e8eb889d23.png)
