### PR TITLE
Ajustando ponto de entrada do App Mobile

### DIFF
--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -1,7 +1,1 @@
 import 'expo-router/entry'
-
-import { registerRootComponent } from 'expo'
-
-import App from './App'
-
-registerRootComponent(App)


### PR DESCRIPTION


# 📋 Descrição

Fiz um teste no mobile e as configurações nativas do expo estavam conflitando com Expo Router, então removi toda a configuração dessa parte do Expo deixei só a do Router.

## 🛠️ Tipo da mudança

- [x] Bug fix

# 🧪 Como isso foi testado?

- [ ] Ao entrar no app com a configuração atual, a tela de splash não desaparece para a entrada das rotas


# ✅ Checklist:

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma auto revisão do meu código
- [x] Minhas alterações não geram novos alertas

