### PR TITLE
Chore: Criar atalhos para caminhos da aplicação

### DIFF
--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -10,14 +10,7 @@ module.exports = function (api) {
         {
           root: ["./src"],
           alias: {
-            "@assets": "./src/assets",
-            "@components": "./src/components",
-            "@screens": "./src/screens",
-            "@utils": "./src/utils",
-            "@services": "./src/services",
-            "@hooks": "./src/hooks",
-            "@contexts": "./src/contexts",
-            "@routes": "./src/routes",
+            "@/*": "./src/*",
           },
         },
       ],

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -1,7 +1,26 @@
 module.exports = function (api) {
   api.cache(true)
   return {
-    presets: ['babel-preset-expo'],
-    plugins: ['nativewind/babel', require.resolve('expo-router/babel')],
+    presets: ["babel-preset-expo"],
+    plugins: [
+      "nativewind/babel",
+      require.resolve("expo-router/babel"),
+      [
+        "module-resolver",
+        {
+          root: ["./src"],
+          alias: {
+            "@assets": "./src/assets",
+            "@components": "./src/components",
+            "@screens": "./src/screens",
+            "@utils": "./src/utils",
+            "@services": "./src/services",
+            "@hooks": "./src/hooks",
+            "@contexts": "./src/contexts",
+            "@routes": "./src/routes",
+          },
+        },
+      ],
+    ],
   }
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@rocketseat/eslint-config": "1.2.0",
+    "babel-plugin-module-resolver": "^5.0.0",
     "eslint": "8.37.0",
     "tailwindcss": "3.3.1"
   },

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -2,14 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@assets/*": ["./src/assets/*"],
-      "@components/*": ["./src/components/*"],
-      "@screens/*": ["./src/screens/*"],
-      "@utils/*": ["./src/utils/*"],
-      "@services/*": ["./src/services/*"],
-      "@hooks/*": ["./src/hooks/*"],
-      "@contexts/*": ["./src/contexts/*"],
-      "@routes/*": ["./src/routes/*"]
+      "@/*": ["./src/*"],
     }
   },
   "extends": "expo/tsconfig.base"

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,4 +1,16 @@
 {
-  "compilerOptions": {},
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@assets/*": ["./src/assets/*"],
+      "@components/*": ["./src/components/*"],
+      "@screens/*": ["./src/screens/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@services/*": ["./src/services/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@contexts/*": ["./src/contexts/*"],
+      "@routes/*": ["./src/routes/*"]
+    }
+  },
   "extends": "expo/tsconfig.base"
 }


### PR DESCRIPTION
# 📋 Descrição

Estas alterações criam atalhos para caminhos comuns da projeto. 

O modelo dos caminhos é inspirado nos caminhos usados nas aulas de React Native do Ignite.

Resolves #38 

## 🛠️ Tipo da mudança

- [X] Nova feature (chore)

# 🧪 Como isso foi testado?

O seguintes testes exploratórios foram realizados:

- [x] O editor de texto reconhece os atalhos é capaz de fazer a auto-importação

![image](https://user-images.githubusercontent.com/24925816/230090351-ae9ce956-f713-4182-9d00-a78c619de8af.png)

![image](https://user-images.githubusercontent.com/24925816/230090725-20b34f70-873f-40b0-ad93-28f3cb59e79f.png)

- [x] O componente é carregado com sucesso

![image](https://user-images.githubusercontent.com/24925816/230091080-323139ef-7c58-45ba-be41-9870312541b7.png)


# ✅ Checklist:

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma auto revisão do meu código
- [ ] Fiz alterações correspondentes na documentação
- [x] Minhas alterações não geram novos alertas
- [ ] Adicionei testes para minhas alterações

