### PR TITLE
chore: Adicionando nestjs ConfigModule para acessarmos o .env

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@nestjs/common": "^9.0.0",
+    "@nestjs/config": "^2.3.1",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
     "@prisma/client": "4.12.0",

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common'
 import { AppController } from './app.controller'
 import { PrismaService } from './database/prisma.service'
+import { ConfigModule } from '@nestjs/config'
 
 @Module({
-  imports: [],
+  imports: [ConfigModule.forRoot()],
   controllers: [AppController],
   providers: [PrismaService],
 })


### PR DESCRIPTION
# 📋 Descrição

Foi adicionado o `ConfigModule` para manipularmos o .env com as variáveis sensíveis  no servidor. O mesmo pode ser inicializado no construtor do controller como o Prisma, e ser ultilizado tanto como `process.env.VAR` como `this.configModule.get('VAR')`.


## 🛠️ Tipo da mudança

- [x] Acessibilidade de código

# ✅ Checklist:

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma auto revisão do meu código
- [x] Fiz alterações correspondentes na documentação
- [x] Minhas alterações não geram novos alertas

