### PR TITLE
fix(mobile): ajuste no job de lint no CI da app mobile e ajustes gerais

### DIFF
--- a/.github/workflows/ci-mobile.yml
+++ b/.github/workflows/ci-mobile.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Clean install dependencies
         run: npm ci
 
-      - name: Lint & Check types
+      - name: Lint
         run: npm run lint
         working-directory: ./apps/mobile
 
@@ -46,6 +46,6 @@ jobs:
       - name: Clean install dependencies
         run: npm ci
 
-      - name: Lint & Check types
+      - name: Types check
         run: npm run types:check
         working-directory: ./apps/mobile

--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Clean install dependencies
         run: npm ci
 
-      - name: Lint & Check types
+      - name: Lint
         run: npm run lint
         working-directory: ./apps/server
 
@@ -46,6 +46,6 @@ jobs:
       - name: Clean install dependencies
         run: npm ci
 
-      - name: Lint & Check types
+      - name: Types check
         run: npm run types:check
         working-directory: ./apps/server

--- a/.github/workflows/pr-titles.yml
+++ b/.github/workflows/pr-titles.yml
@@ -30,6 +30,7 @@ jobs:
           scopes: |
             mobile
             server
+            contracts
           # we allow "cross package" PRs with no scope
           requireScope: false
           # ensure that the subject is lower-case first

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
     "baseUrl": "./",
+    "strictNullChecks": true,
     "paths": {
-      "@/*": ["./app/*"],
+      "@/*": ["./app/*"]
     }
   },
   "extends": "expo/tsconfig.base"


### PR DESCRIPTION
# 📋 Descrição

O job que checa a tipagem da app mobile está apresentando um erro. Este erro ocorre pois o `tsc` está verificando o projeto do expo-router no node_modules, mais especificamente no hook `useFocusEffect`.

Após investigação e vários testes, descobri que nem a propriedade `exclude` nem a `skipLibCheck` servem para definir que o `tsc` ignore o node_modules, apenas os arquivos de tipo, que nesse caso não se aplica pois é um erro de runtime do typescript, ver na imagem abaixo (se alguém tiver mais alguma sugestão estou aberto).

Este PR é uma sugestão de correção desse erro, porém é importante enfatizar que pode acarretar em um efeito colateral no desenvolvimento da app. Para mais informações sobre a propriedade adicionar, [leia a documentação do TS](https://www.typescriptlang.org/tsconfig#strictNullChecks).

**Evidências do problema**
![image](https://user-images.githubusercontent.com/25696006/230661697-8ad2c2ed-5e8a-437a-bef2-503206725323.png)
![image](https://user-images.githubusercontent.com/25696006/230661724-cae387cf-7365-4aaa-a69e-396793846460.png)

A outra alternativa para resolução desse erro seria remover de fato o job, pois não encontrei uma alternativa fora essa da implementação. Irei abrir uma issue no expo-router, depois linko aqui, pq acho que de fato deve ser algo pra alterar na própria lib.

Aproveitei também pra deixar o nome das runs mais adequadas com o que elas estão fazendo, além de criar o scope de `contracts` para a nova app que será criada https://github.com/diego3g/rsxp-2023/pull/76

## 🛠️ Tipo da mudança

- Bug fix

# 🧪 Como isso foi testado?

_Print dos jobs rodando no meu fork_

![image](https://user-images.githubusercontent.com/25696006/230662705-4ab143f8-65df-422c-b594-cfe6553bdb30.png)

_Print dos jobs rodando nesse PR (verifique abaixo)_

![image](https://user-images.githubusercontent.com/25696006/230663126-1b63879e-2a7a-48b2-ae9c-d0a5383f6792.png)

# ✅ Checklist:

- [x] O título do meu PR está seguindo o padrão `<type>(scope): subject`. Por exemplo: `feat(mobile): add new feature`
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma auto revisão do meu código
- [x] Fiz alterações correspondentes na documentação
- [ x Minhas alterações não geram novos alertas
- [ ] Adicionei testes para minhas alterações
