### PR TITLE
feat(server): adicionando auth guard para o backend com validação do clerk

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,1 +1,2 @@
 DATABASE_URL="postgresql://postgres:docker@localhost:5432/rsxp?schema=public"
+CLERK_SECRET_KEY=

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -23,9 +23,11 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@clerk/clerk-sdk-node": "^4.8.2",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^2.3.1",
     "@nestjs/core": "^9.0.0",
+    "@nestjs/passport": "^9.0.3",
     "@nestjs/platform-express": "^9.0.0",
     "@prisma/client": "4.12.0",
     "reflect-metadata": "^0.1.13",

--- a/apps/server/src/app.controller.ts
+++ b/apps/server/src/app.controller.ts
@@ -1,5 +1,7 @@
-import { Controller, Get } from '@nestjs/common'
+import { Controller, Get, Req, UseGuards } from '@nestjs/common'
 import { PrismaService } from './database/prisma.service'
+import { ClerkAuthGuard } from './clerk/clerk.guard'
+import { RequestWithUser } from './clerk/requestInterface.dto'
 
 @Controller()
 export class AppController {
@@ -11,6 +13,14 @@ export class AppController {
 
     return {
       data: users,
+    }
+  }
+
+  @Get('/test-clerk-auth-guard')
+  @UseGuards(ClerkAuthGuard)
+  async get(@Req() req: RequestWithUser) {
+    return {
+      data: req.user,
     }
   }
 }

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common'
 import { AppController } from './app.controller'
 import { PrismaService } from './database/prisma.service'
 import { ConfigModule } from '@nestjs/config'
+import { ClerkService } from './clerk/clerk.service';
 
 @Module({
   imports: [ConfigModule.forRoot()],
   controllers: [AppController],
-  providers: [PrismaService],
+  providers: [PrismaService, ClerkService],
 })
 export class AppModule {}

--- a/apps/server/src/clerk/clerk.guard.ts
+++ b/apps/server/src/clerk/clerk.guard.ts
@@ -1,0 +1,30 @@
+import { ExecutionContext, Injectable } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import { ClerkService } from './clerk.service'
+
+@Injectable()
+export class ClerkAuthGuard extends AuthGuard('jwt') {
+  constructor(private readonly clerkService: ClerkService) {
+    super()
+  }
+
+  async canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest()
+    const authToken = request.headers.authorization
+      ? request.headers.authorization.replace('Bearer ', '')
+      : request.headers.authorization
+
+    if (!authToken) {
+      return false
+    }
+
+    const user = await this.clerkService.authenticateUser(authToken)
+
+    if (!user) {
+      return false
+    }
+
+    request.user = user
+    return true
+  }
+}

--- a/apps/server/src/clerk/clerk.service.ts
+++ b/apps/server/src/clerk/clerk.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common'
+import clerkClient, { Clerk } from '@clerk/clerk-sdk-node'
+import { ConfigService } from '@nestjs/config'
+
+@Injectable()
+export class ClerkService {
+  private readonly clerk: typeof clerkClient
+
+  constructor(private readonly configService: ConfigService) {
+    this.clerk = Clerk({
+      secretKey: this.configService.get('CLERK_SECRET_KEY'),
+    })
+  }
+
+  async authenticateUser(authToken: string) {
+    try {
+      const session = await this.clerk.clients.verifyClient(authToken)
+      return session
+    } catch (error) {
+      return null
+    }
+  }
+}

--- a/apps/server/src/clerk/requestInterface.dto.ts
+++ b/apps/server/src/clerk/requestInterface.dto.ts
@@ -1,0 +1,26 @@
+import { Response } from 'express'
+
+export interface Session {
+  id: string
+  clientId: string
+  userId: string
+  status: string
+  lastActiveAt: number
+  expireAt: number
+  abandonAt: number
+  createdAt: number
+  updatedAt: number
+}
+
+export interface RequestWithUser extends Response {
+  user: {
+    id: string
+    sessionIds: string[]
+    sessions: Session[]
+    signInId: any
+    signUpId: any
+    lastActiveSessionId: string 
+    createdAt: number
+    updatedAt: number
+  }
+}


### PR DESCRIPTION
# 📋 Descrição

Este commit trás a implementação do AuthGuard com validação do Clerk, para evitar furos de segurança na aplicação.

Foram criados 3 arquivos: 
--> **clerk.service:** o serviço que interage diretamente com a api do Clerk, para validar o token jwt enviado
--> **clerk.guard:** o guarda que verifica se um `bearer token` foi enviado no header da apliação, valida o mesmo, e gera os erros ou adiciona ao contexto da requisição o cliente associado ao token
--> **requestInterface**: a interface que faz a junção do Request com a interface do cliente vindo do guarda

Foi adicionado uma nova rota a base da aplicação(`/test-clerk-auth-guard` ) com o fim de demonstrar como o guarda é, e pode ser utilizado para o desenvolvimento

## 🛠️ Tipo da mudança

- [x] Nova feature: autenticação na api

# 🧪 Como isso foi testado?

Foi criado uma aplicação de testes no Clerk, e adicionado a variável de ambiente o token da api. O jwt de um úsuario(salvo no local storage) foi o token ultilizado para acessar a rota.

# ✅ Checklist:

- [x] O título do meu PR está seguindo o padrão `<type>(scope): subject`. Por exemplo: `feat(mobile): add new feature`
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma auto revisão do meu código
- [x] Fiz alterações correspondentes na documentação
- [x] Minhas alterações não geram novos alertas
- [ ] Adicionei testes para minhas alterações
