### PR TITLE
feat(server): adicionando auth guard para o backend com validação do clerk

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,1 +1,2 @@
 DATABASE_URL="postgresql://postgres:docker@localhost:5432/rsxp?schema=public"
+CLERK_SECRET_KEY=

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -23,9 +23,11 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@clerk/clerk-sdk-node": "^4.8.2",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^2.3.1",
     "@nestjs/core": "^9.0.0",
+    "@nestjs/passport": "^9.0.3",
     "@nestjs/platform-express": "^9.0.0",
     "@prisma/client": "4.12.0",
     "reflect-metadata": "^0.1.13",

--- a/apps/server/src/app.controller.ts
+++ b/apps/server/src/app.controller.ts
@@ -1,5 +1,7 @@
-import { Controller, Get } from '@nestjs/common'
+import { Controller, Get, Req, UseGuards } from '@nestjs/common'
 import { PrismaService } from './database/prisma.service'
+import { ClerkAuthGuard } from './clerk/clerk.guard'
+import { RequestWithUser } from './clerk/requestInterface.dto'
 
 @Controller()
 export class AppController {
@@ -11,6 +13,14 @@ export class AppController {
 
     return {
       data: users,
+    }
+  }
+
+  @Get('/test-clerk-auth-guard')
+  @UseGuards(ClerkAuthGuard)
+  async get(@Req() req: RequestWithUser) {
+    return {
+      data: req.user,
     }
   }
 }

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common'
 import { AppController } from './app.controller'
 import { PrismaService } from './database/prisma.service'
 import { ConfigModule } from '@nestjs/config'
+import { ClerkService } from './clerk/clerk.service';
 
 @Module({
   imports: [ConfigModule.forRoot()],
   controllers: [AppController],
-  providers: [PrismaService],
+  providers: [PrismaService, ClerkService],
 })
 export class AppModule {}

--- a/apps/server/src/clerk/clerk.guard.ts
+++ b/apps/server/src/clerk/clerk.guard.ts
@@ -1,0 +1,30 @@
+import { ExecutionContext, Injectable } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import { ClerkService } from './clerk.service'
+
+@Injectable()
+export class ClerkAuthGuard extends AuthGuard('jwt') {
+  constructor(private readonly clerkService: ClerkService) {
+    super()
+  }
+
+  async canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest()
+    const authToken = request.headers.authorization
+      ? request.headers.authorization.replace('Bearer ', '')
+      : request.headers.authorization
+
+    if (!authToken) {
+      return false
+    }
+
+    const user = await this.clerkService.authenticateUser(authToken)
+
+    if (!user) {
+      return false
+    }
+
+    request.user = user
+    return true
+  }
+}

--- a/apps/server/src/clerk/clerk.service.ts
+++ b/apps/server/src/clerk/clerk.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common'
+import clerkClient, { Clerk } from '@clerk/clerk-sdk-node'
+import { ConfigService } from '@nestjs/config'
+
+@Injectable()
+export class ClerkService {
+  private readonly clerk: typeof clerkClient
+
+  constructor(private readonly configService: ConfigService) {
+    this.clerk = Clerk({
+      secretKey: this.configService.get('CLERK_SECRET_KEY'),
+    })
+  }
+
+  async authenticateUser(authToken: string) {
+    try {
+      const session = await this.clerk.clients.verifyClient(authToken)
+      return session
+    } catch (error) {
+      return null
+    }
+  }
+}

--- a/apps/server/src/clerk/requestInterface.dto.ts
+++ b/apps/server/src/clerk/requestInterface.dto.ts
@@ -1,0 +1,26 @@
+import { Response } from 'express'
+
+export interface Session {
+  id: string
+  clientId: string
+  userId: string
+  status: string
+  lastActiveAt: number
+  expireAt: number
+  abandonAt: number
+  createdAt: number
+  updatedAt: number
+}
+
+export interface RequestWithUser extends Response {
+  user: {
+    id: string
+    sessionIds: string[]
+    sessions: Session[]
+    signInId: any
+    signUpId: any
+    lastActiveSessionId: string 
+    createdAt: number
+    updatedAt: number
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,9 +70,11 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@clerk/clerk-sdk-node": "^4.8.2",
         "@nestjs/common": "^9.0.0",
         "@nestjs/config": "^2.3.1",
         "@nestjs/core": "^9.0.0",
+        "@nestjs/passport": "^9.0.3",
         "@nestjs/platform-express": "^9.0.0",
         "@prisma/client": "4.12.0",
         "reflect-metadata": "^0.1.13",
@@ -2186,6 +2188,116 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@clerk/backend": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-0.16.1.tgz",
+      "integrity": "sha512-3cA2FDbNv5jK+iqckV+ZbTdz/Eg69mSOUkd8WTgOGj51sYTxOAr0sOhdhudQhdWhIk4H/43523VdwU3FUtFguQ==",
+      "dependencies": {
+        "@clerk/types": "^3.34.0",
+        "@peculiar/webcrypto": "1.4.1",
+        "@types/node": "16.18.6",
+        "deepmerge": "4.2.2",
+        "node-fetch-native": "1.0.1",
+        "snakecase-keys": "5.4.4",
+        "tslib": "2.4.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@clerk/backend/node_modules/@types/node": {
+      "version": "16.18.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.6.tgz",
+      "integrity": "sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA=="
+    },
+    "node_modules/@clerk/backend/node_modules/deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@clerk/backend/node_modules/snakecase-keys": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.4.tgz",
+      "integrity": "sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==",
+      "dependencies": {
+        "map-obj": "^4.1.0",
+        "snake-case": "^3.0.4",
+        "type-fest": "^2.5.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@clerk/backend/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "node_modules/@clerk/backend/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@clerk/clerk-sdk-node": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-sdk-node/-/clerk-sdk-node-4.8.2.tgz",
+      "integrity": "sha512-r3dZn1mYOiIC3q63V5MFXScDFmxuUBQ/NkAQhzpEBGmLW9sVfMIjZJF0L3C0tSj4eeJbbuDui5Ix0pT9l0inNA==",
+      "dependencies": {
+        "@clerk/backend": "^0.16.1",
+        "@clerk/types": "^3.34.0",
+        "@types/cookies": "0.7.7",
+        "@types/express": "4.17.14",
+        "@types/node-fetch": "2.6.2",
+        "camelcase-keys": "6.2.2",
+        "cookie": "0.5.0",
+        "snakecase-keys": "3.2.1",
+        "tslib": "2.4.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@clerk/clerk-sdk-node/node_modules/@types/express": {
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
+      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@clerk/clerk-sdk-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "node_modules/@clerk/types": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.34.0.tgz",
+      "integrity": "sha512-8eA7bhjlIYvciPuAdCH1b1aOBUv+8kQ6Q5uY0eupgrLjmVXYpsbwLrJJDzL0VSJA5ufTDZdJUZps2PcQkYV+5A==",
+      "dependencies": {
+        "csstype": "3.1.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@clerk/types/node_modules/csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -4435,6 +4547,15 @@
         }
       }
     },
+    "node_modules/@nestjs/passport": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-9.0.3.tgz",
+      "integrity": "sha512-HplSJaimEAz1IOZEu+pdJHHJhQyBOPAYWXYHfAPQvRqWtw4FJF1VXl1Qtk9dcXQX1eKytDtH+qBzNQc19GWNEg==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0",
+        "passport": "^0.4.0 || ^0.5.0 || ^0.6.0"
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-9.4.0.tgz",
@@ -4577,6 +4698,42 @@
       "engines": {
         "node": ">=8.0.0",
         "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
+      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.1.tgz",
+      "integrity": "sha512-eK4C6WTNYxoI7JOabMoZICiyqRRtJB220bh0Mbj5RwRycleZf9BPyZoxsTvpP0FpmVS2aS13NKOuh5/tN3sIRw==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.1",
+        "webcrypto-core": "^1.7.4"
+      },
+      "engines": {
+        "node": ">=10.12.0"
       }
     },
     "node_modules/@prisma/client": {
@@ -6926,7 +7083,6 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -6936,7 +7092,6 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -6946,6 +7101,17 @@
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
+    },
+    "node_modules/@types/cookies": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
+      "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/eslint": {
       "version": "8.37.0",
@@ -6977,7 +7143,6 @@
       "version": "4.17.17",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
       "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
-      "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -6989,7 +7154,6 @@
       "version": "4.17.33",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
       "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -7053,11 +7217,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/keygrip": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
+      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
+    },
     "node_modules/@types/mime": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
-      "dev": true
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -7069,6 +7237,28 @@
       "version": "18.15.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
       "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -7101,8 +7291,7 @@
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/react": {
       "version": "18.0.33",
@@ -7129,7 +7318,6 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
       "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
-      "dev": true,
       "dependencies": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -7947,6 +8135,19 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "dependencies": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
@@ -8819,7 +9020,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
       "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "dev": true,
       "dependencies": {
         "camelcase": "^5.3.1",
         "map-obj": "^4.0.0",
@@ -10182,6 +10382,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/dot-prop": {
@@ -15186,6 +15395,14 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -15268,7 +15485,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -16670,6 +16886,15 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/nocache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-3.0.4.tgz",
@@ -16721,6 +16946,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.1.tgz",
+      "integrity": "sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg=="
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -17346,6 +17576,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/passport": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
+      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
+      "peer": true,
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/password-prompt": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.2.tgz",
@@ -17511,6 +17768,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==",
+      "peer": true
     },
     "node_modules/phosphor-react-native": {
       "version": "1.1.2",
@@ -18084,6 +18347,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
+      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -18170,7 +18449,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -19829,6 +20107,27 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/snakecase-keys": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-3.2.1.tgz",
+      "integrity": "sha512-CjU5pyRfwOtaOITYv5C8DzpZ8XA/ieRsDpr93HI2r6e3YInC6moZpSQbmUtg8cTk58tq2x3jcG2gv+p1IZGmMA==",
+      "dependencies": {
+        "map-obj": "^4.1.0",
+        "to-snake-case": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -21198,6 +21497,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/to-no-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+      "integrity": "sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg=="
+    },
     "node_modules/to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -21243,6 +21547,22 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-snake-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
+      "integrity": "sha512-joRpzBAk1Bhi2eGEYBjukEWHOe/IvclOkiJl3DtA91jV6NwQ3MwXA4FHYeqk8BNp/D8bmi9tcNbRu/SozP0jbQ==",
+      "dependencies": {
+        "to-space-case": "^1.0.0"
+      }
+    },
+    "node_modules/to-space-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+      "integrity": "sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==",
+      "dependencies": {
+        "to-no-case": "^1.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -21974,6 +22294,18 @@
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webcrypto-core": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
+      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/webidl-conversions": {


### PR DESCRIPTION
# 📋 Descrição

Este commit trás a implementação do AuthGuard com validação do Clerk, para evitar furos de segurança na aplicação.

Foram criados 3 arquivos: 
--> **clerk.service:** o serviço que interage diretamente com a api do Clerk, para validar o token jwt enviado
--> **clerk.guard:** o guarda que verifica se um `bearer token` foi enviado no header da apliação, valida o mesmo, e gera os erros ou adiciona ao contexto da requisição o cliente associado ao token
--> **requestInterface**: a interface que faz a junção do Request com a interface do cliente vindo do guarda

Foi adicionado uma nova rota a base da aplicação(`/test-clerk-auth-guard` ) com o fim de demonstrar como o guarda é, e pode ser utilizado para o desenvolvimento

## 🛠️ Tipo da mudança

- [x] Nova feature: autenticação na api

# 🧪 Como isso foi testado?

Foi criado uma aplicação de testes no Clerk, e adicionado a variável de ambiente o token da api. O jwt de um úsuario(salvo no local storage) foi o token ultilizado para acessar a rota.

# ✅ Checklist:

- [x] O título do meu PR está seguindo o padrão `<type>(scope): subject`. Por exemplo: `feat(mobile): add new feature`
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma auto revisão do meu código
- [x] Fiz alterações correspondentes na documentação
- [x] Minhas alterações não geram novos alertas
- [ ] Adicionei testes para minhas alterações
