### PR TITLE
feat(mobile): configuração de mocks para chamadas HTTP

### DIFF
--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -2,6 +2,8 @@ import 'expo-router/entry'
 import { registerRootComponent } from 'expo'
 import { ExpoRoot } from 'expo-router'
 
+import './server-mock'
+
 export function App() {
   const ctx = require.context('./src/app')
   return <ExpoRoot context={ctx} />

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -41,6 +41,7 @@
     "@rocketseat/eslint-config": "1.2.0",
     "babel-plugin-module-resolver": "^5.0.0",
     "eslint": "8.37.0",
+    "miragejs": "^0.1.47",
     "react-native-svg-transformer": "^1.0.0",
     "tailwindcss": "3.3.1"
   },

--- a/apps/mobile/server-mock/index.ts
+++ b/apps/mobile/server-mock/index.ts
@@ -1,0 +1,12 @@
+import { startServer } from './server'
+
+if (process.env.NODE_ENV === 'development') {
+  // @ts-ignore
+  if (window.server) {
+    // @ts-ignore
+    window.server.shutdown()
+  }
+
+  // @ts-ignore
+  window.server = startServer()
+}

--- a/apps/mobile/server-mock/routes/index.ts
+++ b/apps/mobile/server-mock/routes/index.ts
@@ -1,0 +1,14 @@
+import { BASE_URL } from '@env'
+
+export default function routes() {
+  this.urlPrefix = `${BASE_URL}`
+  this.namespace = ''
+
+  this.get('users/diego3g', () => {
+    return { login: 'mock-mirage' }
+  })
+
+  this.passthrough((request) => {
+    return !request.url.includes(BASE_URL)
+  })
+}

--- a/apps/mobile/server-mock/server.ts
+++ b/apps/mobile/server-mock/server.ts
@@ -1,0 +1,10 @@
+import { Server } from 'miragejs'
+import routes from './routes'
+
+const config = { routes }
+
+export function startServer() {
+  return new Server({
+    ...config,
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@rocketseat/eslint-config": "1.2.0",
         "babel-plugin-module-resolver": "^5.0.0",
         "eslint": "8.37.0",
+        "miragejs": "^0.1.47",
         "react-native-svg-transformer": "^1.0.0",
         "tailwindcss": "3.3.1"
       }
@@ -6169,6 +6170,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@miragejs/pretender-node-polyfill": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@miragejs/pretender-node-polyfill/-/pretender-node-polyfill-0.1.2.tgz",
+      "integrity": "sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==",
+      "dev": true
     },
     "node_modules/@nestjs/cli": {
       "version": "9.3.0",
@@ -13179,6 +13186,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fake-xml-http-request": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-2.1.2.tgz",
+      "integrity": "sha512-HaFMBi7r+oEC9iJNpc3bvcW7Z7iLmM26hPDmlb0mFwyANSsOQAtJxbdWsXITKOzZUyMYK0zYCv3h5yDj9TsiXg==",
+      "dev": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
@@ -14422,6 +14435,12 @@
     "node_modules/infer-owner": {
       "version": "1.0.4",
       "license": "ISC"
+    },
+    "node_modules/inflected": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/inflected/-/inflected-2.1.0.tgz",
+      "integrity": "sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w==",
+      "dev": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -17249,14 +17268,74 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "node_modules/lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
+      "dev": true
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true
+    },
+    "node_modules/lodash.compact": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.compact/-/lodash.compact-3.0.1.tgz",
+      "integrity": "sha512-2ozeiPi+5eBXW1CLtzjk8XQFhQOEMwwfxblqeq6EGyTxZJ1bPATqilY0e6g2SLQpP4KuMeuioBhEnWz5Pr7ICQ==",
+      "dev": true
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "license": "MIT"
+    },
+    "node_modules/lodash.find": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+      "integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==",
+      "dev": true
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "dev": true
+    },
+    "node_modules/lodash.forin": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.forin/-/lodash.forin-4.4.0.tgz",
+      "integrity": "sha512-APldePP4yvGhMcplVxv9L+exdLHMRHRhH1Q9O70zRJMm9HbTm6zxaihXtNl+ICOBApeFWoH7jNmFr/L4XfWeiQ==",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
+    "node_modules/lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g==",
+      "dev": true
+    },
+    "node_modules/lodash.invokemap": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.invokemap/-/lodash.invokemap-4.6.0.tgz",
+      "integrity": "sha512-CfkycNtMqgUlfjfdh2BhKO/ZXrP8ePOX5lEU/g0R3ItJcnuxWDwokMGKx1hWcfOikmyOVx6X9IwWnDGlgKl61w==",
+      "dev": true
+    },
+    "node_modules/lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+      "dev": true
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -17267,6 +17346,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true
+    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "dev": true,
@@ -17276,6 +17361,24 @@
       "version": "4.1.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.lowerfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.lowerfirst/-/lodash.lowerfirst-4.3.1.tgz",
+      "integrity": "sha512-UUKX7VhP1/JL54NXg2aq/E1Sfnjjes8fNYTNkPU8ZmsaVeBvPHKdbNaN79Re5XRL01u6wbq3j0cbYZj71Fcu5w==",
+      "dev": true
+    },
+    "node_modules/lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==",
+      "dev": true
+    },
+    "node_modules/lodash.mapvalues": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
+      "dev": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -17291,6 +17394,12 @@
       "version": "4.6.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==",
+      "dev": true
     },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
@@ -17311,10 +17420,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
+      "dev": true
+    },
     "node_modules/lodash.upperfirst": {
       "version": "4.3.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.values": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
+      "integrity": "sha512-r0RwvdCv8id9TUblb/O7rYPwVy6lerCbcawrfdo9iC/1t1wsNMJknO79WNBgwkH0hIeJ08jmvvESbFpNb4jH0Q==",
+      "dev": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -18690,6 +18811,43 @@
     "node_modules/minizlib/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC"
+    },
+    "node_modules/miragejs": {
+      "version": "0.1.47",
+      "resolved": "https://registry.npmjs.org/miragejs/-/miragejs-0.1.47.tgz",
+      "integrity": "sha512-99tuCbIAlMhNhyF3s5d3+5/FdJ7O4jSq/5e3e+sDv7L8dZdwJuwutXe0pobJ7hm6yRChTDjK+Nn8dZZd175wbg==",
+      "dev": true,
+      "dependencies": {
+        "@miragejs/pretender-node-polyfill": "^0.1.0",
+        "inflected": "^2.0.4",
+        "lodash.assign": "^4.2.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.compact": "^3.0.1",
+        "lodash.find": "^4.6.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.forin": "^4.4.0",
+        "lodash.get": "^4.4.2",
+        "lodash.has": "^4.5.2",
+        "lodash.invokemap": "^4.6.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.lowerfirst": "^4.3.1",
+        "lodash.map": "^4.6.0",
+        "lodash.mapvalues": "^4.6.0",
+        "lodash.pick": "^4.4.0",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.uniq": "^4.5.0",
+        "lodash.uniqby": "^4.7.0",
+        "lodash.values": "^4.3.0",
+        "pretender": "^3.4.7"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
@@ -20157,6 +20315,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/pretender": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/pretender/-/pretender-3.4.7.tgz",
+      "integrity": "sha512-jkPAvt1BfRi0RKamweJdEcnjkeu7Es8yix3bJ+KgBC5VpG/Ln4JE3hYN6vJym4qprm8Xo5adhWpm3HCoft1dOw==",
+      "dev": true,
+      "dependencies": {
+        "fake-xml-http-request": "^2.1.2",
+        "route-recognizer": "^0.3.3"
+      }
+    },
     "node_modules/prettier": {
       "version": "2.8.7",
       "dev": true,
@@ -21446,6 +21614,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/route-recognizer": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.3.4.tgz",
+      "integrity": "sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==",
+      "dev": true
     },
     "node_modules/run-async": {
       "version": "2.4.1",


### PR DESCRIPTION
# 📋 Descrição

Adicionado setup do Mirage JS para utilização de mocks durante o desenvolvimento do app mobile. 

Estou abrindo PR com o intuito de obter feedback sobre a implementação que fiz, onde acabei seguindo a própria [documentação do Mirage JS](https://miragejs.com/quickstarts/react-native/development/) para realizar o setup e a organização de pastas proposta no [starter kit do Fábio Vedovelli](https://github.com/vedovelli/miragejs-starter-kit).

Como os contratos #53 ainda não estão totalmente definidos, fiz apenas a inclusão de uma rota de exemplo.

Acredito que a PR esteja apta para realizar o merge apenas quando adicionar os mocks definidos pelos contratos, ou seja, após o merge da PR #76 

Adicionei uma lógica de passthrough para ignorar todas as chamadas que sejam diferentes da variável BASE_URL. Isso se fez necessário para não interceptar as chamadas realizadas pelo Clerk.

Fixes #62 

## 🛠️ Tipo da mudança

Exclua as opções que não são relevantes.

- [x] Nova feature: adicionado setup de mocks

# 🧪 Como isso foi testado?

Realizados apenas testes manuais na aplicação através do exemplo de request existente na aplicação

# ✅ Checklist:

- [x] O título do meu PR está seguindo o padrão `<type>(scope): subject`. Por exemplo: `feat(mobile): add new feature`
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma auto revisão do meu código
- [ ] Fiz alterações correspondentes na documentação
- [x] Minhas alterações não geram novos alertas
- [ ] Adicionei testes para minhas alterações
