### PR TITLE
docs(readme): Adicionando comando do prisma para rodar as migration no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ cp .env.example .env
 # Subir o serviço do PostgreSQL via docker (caso não tenha instalado o PostgreSQL em seu computador)
 docker compose up -d
 
+# Rodar as migrations do prisma
+npx prisma migrate dev
+
 # Subir o servidor HTTP
 npm run start:dev
 ```


### PR DESCRIPTION
# 📋 Descrição

Antes de executar o comando `npm run start:dev` para iniciar o servidor, é necessário rodar as migrations primeiro. É importante incluir o comando `npx prisma migrate dev` na seção 'Executando o projeto' do arquivo README, pois quem seguir os passos pode esquecer de rodar as migrations.

# ✅ Checklist:

- [x] O título do meu PR está seguindo o padrão `<type>(scope): subject`. Por exemplo: `feat(mobile): add new feature`
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma auto revisão do meu código
- [x] Fiz alterações correspondentes na documentação
- [x] Minhas alterações não geram novos alertas
- [ ] Adicionei testes para minhas alterações
