### PR TITLE
feat(server): adicionando auth guard para o backend com validação do clerk

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,5 +1,6 @@
 DATABASE_URL="postgresql://postgres:docker@localhost:5432/rsxp?schema=public"
 CLERK_SECRET_KEY=
+CLERK_JWT_KEY=
 
 # Sympla API docs: https://www.sympla.com.br/api-doc/index.html
 SYMPLA_TOKEN=""

--- a/apps/server/src/app.controller.ts
+++ b/apps/server/src/app.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Post, Req, Res, Get } from '@nestjs/common'
-import { sessions, users } from '@clerk/clerk-sdk-node'
+import { Controller, Post, Req, Res, Get, UseGuards } from '@nestjs/common'
+import { RequireAuthProp, sessions, users } from '@clerk/clerk-sdk-node'
 import { Request, Response } from 'express'
 
 import { PrismaService } from './database/prisma.service'
+import { ClerkGuard } from './clerk/clerk.guard'
 
 @Controller()
 export class AppController {
@@ -43,5 +44,13 @@ export class AppController {
     return response.status(400).json({
       error: 'Session not verified',
     })
+  }
+
+  @Get('/auth')
+  @UseGuards(ClerkGuard)
+  async get(@Req() req: RequireAuthProp<Request>) {
+    return {
+      data: req.auth,
+    }
   }
 }

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -14,6 +14,7 @@ import { SymplaService } from './sympla/sympla.service'
         const envSchema = z.object({
           DATABASE_URL: z.string(),
           CLERK_SECRET_KEY: z.string(),
+          CLERK_JWT_KEY: z.string(),
           SYMPLA_TOKEN: z.string(),
           SYMPLA_EVENT_ID: z.string(),
           THROTTLE_TTL: z.string(),

--- a/apps/server/src/clerk/clerk.guard.ts
+++ b/apps/server/src/clerk/clerk.guard.ts
@@ -1,0 +1,25 @@
+import { RequireAuthProp } from '@clerk/clerk-sdk-node'
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable,
+} from '@nestjs/common'
+import { Observable } from 'rxjs'
+
+@Injectable()
+export class ClerkGuard implements CanActivate {
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request: RequireAuthProp<Request> = context
+      .switchToHttp()
+      .getRequest()
+    if (request.auth.userId) {
+      return true
+    } else {
+      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED)
+    }
+  }
+}

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -3,6 +3,7 @@ import { NestFactory } from '@nestjs/core'
 import { AppModule } from './app.module'
 import helmet from 'helmet'
 import { Logger } from '@nestjs/common'
+import { ClerkExpressWithAuth } from '@clerk/clerk-sdk-node'
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -10,6 +11,7 @@ async function bootstrap() {
   })
 
   app.use(helmet())
+  app.use(ClerkExpressWithAuth({ jwtKey: process.env.CLERK_JWT_KEY }))
 
   await app.listen(3333)
 


### PR DESCRIPTION
# 📋 Descrição

Este commit trás a implementação de um Guarda com validação do Clerk, para evitar furos de segurança na aplicação.

Foi adicionado uma nova rota a base da aplicação(`/auth` ) com o fim de demonstrar como o Guarda é, e pode ser utilizado para o desenvolvimento.

É necessário configurar uma key para os jwts gerados no .env!
Caso não exista uma chave, um erro será lançado por validação do Zod!

## 🛠️ Tipo da mudança

- [x] Nova feature: autenticação na api

# 🧪 Como isso foi testado?

# ✅ Checklist:

- [x] O título do meu PR está seguindo o padrão `<type>(scope): subject`. Por exemplo: `feat(mobile): add new feature`
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma auto revisão do meu código
- [x] Fiz alterações correspondentes na documentação
- [x] Minhas alterações não geram novos alertas
