### PR TITLE
feat(server): rota 'root' padrão da api

### DIFF
--- a/apps/server/src/app.controller.ts
+++ b/apps/server/src/app.controller.ts
@@ -19,6 +19,10 @@ import { SymplaService } from './sympla/sympla.service'
 @Controller()
 export class AppController {
   constructor(private prisma: PrismaService, private sympla: SymplaService) {}
+  @Get()
+  handleGet(): {message: string} {
+    return { message: 'online' }
+  }
 
   @Get('/tickets/link')
   @UseGuards(ClerkGuard)


### PR DESCRIPTION
# 📋 Descrição

Depois da live de hoje(25/04), vi que o pull request que trouxe as rotas do ticket acabaram por remover a rota root da api, retornand um 404 quando alguém tentava acessa-lá!

Este pull trás de volta a implementação da rota root!

## 🛠️ Tipo da mudança

Exclua as opções que não são relevantes.

- [x] Nova feature: Roota root

# 🧪 Como isso foi testado?

Foi testado localmente!

# ✅ Checklist:

- [x] O título do meu PR está seguindo o padrão `<type>(scope): subject`. Por exemplo: `feat(mobile): add new feature`
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma auto revisão do meu código
- [x] Fiz alterações correspondentes na documentação
- [ x Minhas alterações não geram novos alertas
